### PR TITLE
Get permission class from entity manager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.8
 
 group = "de.ebf"
 archivesBaseName = "spring-granular-permissions"
-version = "1.0.1"
+version = "1.0.2"
 
 jar {
     manifest {


### PR DESCRIPTION
After converting a project from java to kotlin I was facing the following error message:

`java.lang.IllegalArgumentException: Not an entity: class de.ebf.files.backend.model.Permission`

This error occurs because jpaEntityTypeMap in [MetaModelImpl](https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetamodelImpl.java#L514) contains a different instance of the *Permission* entity than what is queried for during [permission initialization](https://github.com/ebf/spring-granular-permissions/blob/master/src/main/java/de/ebf/security/init/InitPermissions.java#L78) since the underlying class is instantiated using `Class.for` instead of retrieved from the Entity Manager.
![screen shot 2018-06-11 at 13 40 28](https://user-images.githubusercontent.com/3786617/41229733-6844bab4-6d7d-11e8-8de5-de67c91c8c4c.png)

My first instinct to fix this issue was to override `hashCode()` and `equals()` in my Permission class, however, these are never called, not sure why. I have overriden `hashCode` and `equals` in the Java implementation as well and I *assume* that this is why it works in the first place.

I was only able to resolve this by getting the `Permission` entity from the entity manager instead of instantiating it using `Class.for`.

@iznenad if you have any ideas, please let me know

Thx